### PR TITLE
feat: 6.5.10.27930

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Pod includes sdk list:
 ### Usage
 Update your Podfile:
 ```
-pod 'ZoomSDK', '6.4.10.25465'
+pod 'ZoomSDK', '6.5.10.27930'
 ```
 
 
@@ -23,6 +23,7 @@ pod 'ZoomSDK', '6.4.10.25465'
 
 |    Version    | Notes                                  | 
 |:-------------:|:---------------------------------------|
+| 6.5.10.27930  |                                        |
 | 6.4.10.25465  |                                        |
 | 6.2.11.20350  |                                        |
 | 6.1.0.16235   | Minimum iOS is 13.0                    |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Architectures may vary between pods.
 
 
 Pod includes sdk list:
-- MobileRTC.framework
-- MobileRTCScreenShare.framework
+- MobileRTC.xcframework
+- MobileRTCScreenShare.xcframework
+- zoomcml.xcframework
 - MobileRTCResources.bundle
 
 ### Usage
@@ -23,7 +24,7 @@ pod 'ZoomSDK', '6.5.10.27930'
 
 |    Version    | Notes                                  | 
 |:-------------:|:---------------------------------------|
-| 6.5.10.27930  |                                        |
+| 6.5.10.27930  | Included zoomcml                       |
 | 6.4.10.25465  |                                        |
 | 6.2.11.20350  |                                        |
 | 6.1.0.16235   | Minimum iOS is 13.0                    |

--- a/ZoomSDK.podspec
+++ b/ZoomSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "ZoomSDK"
-  s.version      = "6.4.10.25465"
+  s.version      = "6.5.10.27930"
   s.summary      = "Pod for zoom-sdk-ios"
   s.description  = <<-DESC
                   Pod for zoom-sdk-ios.
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = { "author" => "zvsx001@gmail.com" }
   s.platform     = :ios, "13.0"
 
-  s.source = { :http => 'https://github.com/zoom-us-community/zoom-sdk-pods/releases/download/zoom-releases/zoom-sdk-ios-6.4.10.25465.zip' }
+  s.source = { :http => 'https://github.com/zoom-us-community/zoom-sdk-pods/releases/download/zoom-releases/zoom-sdk-ios-6.5.10.27930.zip' }
   s.requires_arc = true
 
   s.vendored_frameworks =  "**/lib/MobileRTC.xcframework", "**/lib/MobileRTCScreenShare.xcframework"

--- a/ZoomSDK.podspec
+++ b/ZoomSDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source = { :http => 'https://github.com/zoom-us-community/zoom-sdk-pods/releases/download/zoom-releases/zoom-sdk-ios-6.5.10.27930.zip' }
   s.requires_arc = true
 
-  s.vendored_frameworks =  "**/lib/MobileRTC.xcframework", "**/lib/MobileRTCScreenShare.xcframework"
+  s.vendored_frameworks =  "**/lib/MobileRTC.xcframework", "**/lib/MobileRTCScreenShare.xcframework", "**/lib/zoomcml.xcframework"
   s.resource = '**/lib/MobileRTCResources.bundle'
 
   s.libraries = "sqlite3", "z.1.2.5", "c++"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,7 +8,7 @@ Run `bundle install` to install specified version of CocoaPods
 
 #### New sdk required
 
-1) Download sdk .zip from zoom marketplace (for example `zoom-sdk-ios-6.4.10.25465.zip`)
+1) Download sdk .zip from zoom marketplace (for example `zoom-sdk-ios-6.5.10.27930.zip`)
 2) Edit existing release https://github.com/zoom-us-community/zoom-sdk-pods/releases/edit/zoom-releases
 3) Upload the downloaded .zip file
 
@@ -27,7 +27,7 @@ pod 'ZoomSDK', :path => '/Users/zvsx001/work/opensource/zoom-sdk-pods'
 Make sure to remove `ZoomSDK` from `Podfile.lock`.
 4) Update version in podspec (e.g. `react-native-zoom-us/RNZoomUs.podspec`):
 ```Podfile
-s.dependency "ZoomSDK", '6.4.10.25465'
+s.dependency "ZoomSDK", '6.5.10.27930'
 ```
 
 #### 2 Lint

--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 
 REPO=https://github.com/zoom-us-community/zoom-sdk-pods/releases/download/zoom-releases
-FILE=zoom-sdk-ios-6.4.10.25465.zip
+FILE=zoom-sdk-ios-6.5.10.27930.zip
 
 curl "$REPO/$FILE" -O -J -L
 tar -xf "$FILE"


### PR DESCRIPTION
Note that I included `zoomcml.xcframework` because of err: `Thread 1: signal SIGABRT` (see https://devforum.zoom.us/t/crash-loading-app-embedding-meeting-sdk-without-zoomcml-xcframework/137091)

### Test plan
- [x] Make sure `bundle exec pod spec lint --verbose --allow-warnings` passes on M1
- [x] Init SDK and join meeting on iPhone 8